### PR TITLE
Tenants managing

### DIFF
--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -514,6 +514,22 @@ namespace Autofac.Multitenant
         }
 
         /// <summary>
+        /// Returns collection of all registered tenant IDs.
+        /// </summary>
+        public ICollection<object> GetTenantsIds()
+        {
+            _readWriteLock.EnterReadLock();
+            try
+            {
+                return new List<object>(_tenantLifetimeScopes.Keys);
+            }
+            finally
+            {
+                _readWriteLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
         /// Returns whether the given tenant ID has been configured.
         /// </summary>
         /// <param name="tenantId">The tenant ID to test.</param>
@@ -560,6 +576,27 @@ namespace Autofac.Multitenant
                 }
 
                 return false;
+            }
+            finally
+            {
+                _readWriteLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Clears all tenants configurations and disposes the associated lifetime scopes.
+        /// </summary>
+        public void ClearTenants()
+        {
+            _readWriteLock.EnterWriteLock();
+            try
+            {
+                foreach (var tenantScope in _tenantLifetimeScopes.Values)
+                {
+                    tenantScope.Dispose();
+                }
+
+                _tenantLifetimeScopes.Clear();
             }
             finally
             {

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -514,9 +514,9 @@ namespace Autofac.Multitenant
         }
 
         /// <summary>
-        /// Returns collection of all registered tenant IDs.
+        /// Returns collection of all registered tenants IDs.
         /// </summary>
-        public ICollection<object> GetTenantsIds()
+        public IEnumerable<object> GetTenants()
         {
             _readWriteLock.EnterReadLock();
             try

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Autofac;
 using Autofac.Multitenant;
 using Autofac.Multitenant.Test.Stubs;
@@ -616,7 +617,7 @@ namespace Autofac.Multitenant.Test
             mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
 
             var registeredTenants = mtc.GetTenantsIds();
-            var tenantScopes = new System.Collections.Generic.List<ILifetimeScope>();
+            var tenantScopes = new List<ILifetimeScope>();
             foreach (var tenantId in registeredTenants)
             {
                 tenantScopes.Add(mtc.GetTenantScope(tenantId));
@@ -626,8 +627,6 @@ namespace Autofac.Multitenant.Test
 
             foreach (var tenantScope in tenantScopes)
             {
-                Assert.Throws<ObjectDisposedException>(() => tenantScope.Resolve<IStubDependency1>());
-                Assert.Throws<ObjectDisposedException>(() => tenantScope.Resolve<IStubDependency1>());
                 Assert.Throws<ObjectDisposedException>(() => tenantScope.Resolve<IStubDependency1>());
             }
         }
@@ -703,7 +702,7 @@ namespace Autofac.Multitenant.Test
             mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
 
             var registeredTenants = mtc.GetTenantsIds();
-            var tenantsStubs = new System.Collections.Generic.List<StubDisposableDependency>();
+            var tenantsStubs = new List<StubDisposableDependency>();
             foreach (var tenantId in registeredTenants)
             {
                 strategy.TenantId = tenantId;

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Autofac;
 using Autofac.Multitenant;
 using Autofac.Multitenant.Test.Stubs;
@@ -540,7 +541,7 @@ namespace Autofac.Multitenant.Test
         }
 
         [Fact]
-        public void GetTenantsIds_CheckRegistered()
+        public void GetTenants_CheckRegistered()
         {
             var strategy = new StubTenantIdentificationStrategy()
             {
@@ -551,7 +552,7 @@ namespace Autofac.Multitenant.Test
             mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
             mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
 
-            var registeredTenants = mtc.GetTenantsIds();
+            var registeredTenants = mtc.GetTenants().ToList();
             Assert.Equal(registeredTenants.Count, 3);
 
             foreach (var tenantId in registeredTenants)
@@ -577,7 +578,7 @@ namespace Autofac.Multitenant.Test
 
             mtc.ClearTenants();
 
-            Assert.Equal(mtc.GetTenantsIds().Count, 0);
+            Assert.Equal(mtc.GetTenants().Count(), 0);
         }
 
         [Fact]
@@ -594,7 +595,7 @@ namespace Autofac.Multitenant.Test
             mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
             mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
 
-            var registeredTenants = mtc.GetTenantsIds();
+            var registeredTenants = mtc.GetTenants();
             mtc.ClearTenants();
 
             foreach (var tenantId in registeredTenants)
@@ -616,7 +617,7 @@ namespace Autofac.Multitenant.Test
             mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
             mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
 
-            var registeredTenants = mtc.GetTenantsIds();
+            var registeredTenants = mtc.GetTenants();
             var tenantScopes = new List<ILifetimeScope>();
             foreach (var tenantId in registeredTenants)
             {
@@ -701,7 +702,7 @@ namespace Autofac.Multitenant.Test
             mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
             mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
 
-            var registeredTenants = mtc.GetTenantsIds();
+            var registeredTenants = mtc.GetTenants();
             var tenantsStubs = new List<StubDisposableDependency>();
             foreach (var tenantId in registeredTenants)
             {

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -537,5 +537,185 @@ namespace Autofac.Multitenant.Test
 
             Assert.IsType<StubDependency1Impl3>(mtc.Resolve<IStubDependency1>());
         }
+
+        [Fact]
+        public void GetTenantsIds_CheckRegistered()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl1>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+
+            var registeredTenants = mtc.GetTenantsIds();
+            Assert.Equal(registeredTenants.Count, 3);
+
+            foreach (var tenantId in registeredTenants)
+            {
+                var scope = mtc.GetTenantScope(tenantId);
+                Assert.NotNull(scope);
+            }
+        }
+
+        [Fact]
+        public void ClearTenants_EnsureRegisteredTenantsCountIsZero()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var builder = new ContainerBuilder();
+            builder.RegisterType<StubDependency1Impl1>().AsImplementedInterfaces();
+            var mtc = new MultitenantContainer(strategy, builder.Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+
+            mtc.ClearTenants();
+
+            Assert.Equal(mtc.GetTenantsIds().Count, 0);
+        }
+
+        [Fact]
+        public void ClearTenants_ShowFallback()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var builder = new ContainerBuilder();
+            builder.RegisterType<StubDependency1Impl1>().AsImplementedInterfaces();
+            var mtc = new MultitenantContainer(strategy, builder.Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+
+            var registeredTenants = mtc.GetTenantsIds();
+            mtc.ClearTenants();
+
+            foreach (var tenantId in registeredTenants)
+            {
+                strategy.TenantId = tenantId;
+                Assert.IsType<StubDependency1Impl1>(mtc.Resolve<IStubDependency1>());
+            }
+        }
+
+        [Fact]
+        public void ClearTenants_ShowDisposal()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl1>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+
+            var registeredTenants = mtc.GetTenantsIds();
+            var tenantScopes = new System.Collections.Generic.List<ILifetimeScope>();
+            foreach (var tenantId in registeredTenants)
+            {
+                tenantScopes.Add(mtc.GetTenantScope(tenantId));
+            }
+
+            mtc.ClearTenants();
+
+            foreach (var tenantScope in tenantScopes)
+            {
+                Assert.Throws<ObjectDisposedException>(() => tenantScope.Resolve<IStubDependency1>());
+                Assert.Throws<ObjectDisposedException>(() => tenantScope.Resolve<IStubDependency1>());
+                Assert.Throws<ObjectDisposedException>(() => tenantScope.Resolve<IStubDependency1>());
+            }
+        }
+
+        [Fact]
+        public void ClearTenants_ConfigureAfterClearing()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var builder = new ContainerBuilder();
+            builder.RegisterType<StubDependency1Impl1>().AsImplementedInterfaces();
+            var mtc = new MultitenantContainer(strategy, builder.Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+
+            mtc.ClearTenants();
+
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+
+            Assert.IsType<StubDependency1Impl3>(mtc.Resolve<IStubDependency1>());
+            strategy.TenantId = "tenant2";
+            Assert.IsType<StubDependency1Impl2>(mtc.Resolve<IStubDependency1>());
+            strategy.TenantId = "tenant3";
+            Assert.IsType<StubDependency1Impl2>(mtc.Resolve<IStubDependency1>());
+        }
+
+        [Fact]
+        public void ClearTenants_ConfigureAfterClearingFailCaseDemo()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var builder = new ContainerBuilder();
+            builder.RegisterType<StubDependency1Impl1>().AsImplementedInterfaces();
+            var mtc = new MultitenantContainer(strategy, builder.Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces());
+
+            mtc.ClearTenants();
+
+            // contextual tenant is still "tenant1"; this will force creation of container-configured tenant
+            mtc.Resolve<IStubDependency1>();
+            Assert.Throws<InvalidOperationException>(() => mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl3>().AsImplementedInterfaces()));
+
+            // contextual tenant is still "tenant2"; this will force creation of container-configured tenant
+            strategy.TenantId = "tenant2";
+            mtc.Resolve<IStubDependency1>();
+            Assert.Throws<InvalidOperationException>(() => mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces()));
+
+            // contextual tenant is still "tenant3"; this will force creation of container-configured tenant
+            strategy.TenantId = "tenant3";
+            mtc.Resolve<IStubDependency1>();
+            Assert.Throws<InvalidOperationException>(() => mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces()));
+        }
+
+        [Fact]
+        public void ClearTenants_TenantSingleton()
+        {
+            var strategy = new StubTenantIdentificationStrategy()
+            {
+                TenantId = "tenant1",
+            };
+            var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+            mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
+            mtc.ConfigureTenant("tenant2", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
+            mtc.ConfigureTenant("tenant3", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
+
+            var registeredTenants = mtc.GetTenantsIds();
+            var tenantsStubs = new System.Collections.Generic.List<StubDisposableDependency>();
+            foreach (var tenantId in registeredTenants)
+            {
+                strategy.TenantId = tenantId;
+                tenantsStubs.Add(mtc.Resolve<StubDisposableDependency>());
+            }
+
+            mtc.ClearTenants();
+
+            foreach (var tenantStub in tenantsStubs)
+            {
+                Assert.True(tenantStub.IsDisposed);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added two methods:
1. `GetTenantsIds` for receiving collection of registered tenants Ids.
2. `ClearTenants` for removing all tenants.

Fixes #9.