### PR TITLE
Fix #14 - Compatibility with Autofac 5.0 pre-release

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
+    <clear />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v2" />
+    <add key="NuGet v3" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.2.1.{build}
+version: 5.0.0.{build}
 
 configuration: Release
 

--- a/src/Autofac.Multitenant/Autofac.Multitenant.csproj
+++ b/src/Autofac.Multitenant/Autofac.Multitenant.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Autofac extension for multitenant application support.</Description>
-    <VersionPrefix>4.2.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <TargetFrameworks>net451;netstandard1.1;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.0.0" />
+    <PackageReference Include="Autofac" Version="5.0.0-ResolvedSe-00585" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -607,8 +607,7 @@ namespace Autofac.Multitenant
         /// <summary>
         /// Resolve an instance of the provided registration within the current tenant context.
         /// </summary>
-        /// <param name="registration">The registration to resolve.</param>
-        /// <param name="parameters">Parameters for the instance.</param>
+        /// <param name="request">The resolve request.</param>
         /// <returns>The component instance.</returns>
         /// <exception cref="Autofac.Core.Registration.ComponentNotRegisteredException">
         /// Thrown if an attempt is made to resolve a component that is not registered
@@ -619,9 +618,9 @@ namespace Autofac.Multitenant
         /// if the component registered requires another component be available
         /// but that required component is not available, this exception will be thrown.
         /// </exception>
-        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object ResolveComponent(ResolveRequest request)
         {
-            return this.GetCurrentTenantScope().ResolveComponent(registration, parameters);
+            return this.GetCurrentTenantScope().ResolveComponent(request);
         }
 
         /// <summary>


### PR DESCRIPTION
Changed MultitenantContainer to use the new ResolveRequest in it's ResolveComponent implementation.

Updated Autofac reference in project to reference pre-release.

If you create a v5-updates branch in the target project, I can change the target of the PR (or it can go straight into develop, because I can't see many other changes coming in to the next Autofac.Multitenant release).