### PR TITLE
chore: update to Autofac v6 stable

### DIFF
--- a/src/Autofac.Multitenant/Autofac.Multitenant.csproj
+++ b/src/Autofac.Multitenant/Autofac.Multitenant.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.0.0-develop-01134" />
+    <PackageReference Include="Autofac" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
* Update to V6 stable

`Autofac.Extensions.DependencyInjection` 6.0.0 is still installed on the Integration test project. Will update that with a dedicated PR since it's not required for the release.