### PR TITLE
Thread-affinity issue during async dispose fixed

### DIFF
--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -626,7 +626,7 @@ public class MultitenantContainer : Disposable, IContainer
     {
         if (disposing)
         {
-            await _semaphore.WaitAsync();
+            await _semaphore.WaitAsync().ConfigureAwait(false);
 
             try
             {

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -85,7 +85,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// <summary>
     /// Flag that disallows creating a new scope while disposing or after that.
     /// </summary>
-    private int _isDisposed = 0;
+    private int _isDisposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MultitenantContainer"/> class.

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Autofac.Core.Lifetime;
+using Autofac.Core.Resolving;
 using Autofac.Multitenant.Test.Stubs;
 
 namespace Autofac.Multitenant.Test;
@@ -767,5 +769,53 @@ public class MultitenantContainerFixture
         using var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
 
         Assert.NotNull(mtc.DiagnosticSource);
+    }
+
+    [Fact]
+    public void ResolveOperationBeginning_FiresWhenResolving()
+    {
+        var strategy = new StubTenantIdentificationStrategy()
+        {
+            TenantId = "tenant1",
+        };
+        using var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+        mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl1>().As<IStubDependency1>());
+
+        Assert.Raises<ResolveOperationBeginningEventArgs>(
+            e => mtc.ResolveOperationBeginning += e,
+            e => mtc.ResolveOperationBeginning -= e,
+            () => mtc.GetTenantScope("tenant1").Resolve<IStubDependency1>());
+    }
+
+    [Fact]
+    public void ChildLifetimeScopeBeginning_FiresWhenChildScopeIsCreated()
+    {
+        var strategy = new StubTenantIdentificationStrategy()
+        {
+            TenantId = "tenant1",
+        };
+        using var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+        mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl1>().As<IStubDependency1>());
+
+        Assert.Raises<LifetimeScopeBeginningEventArgs>(
+            e => mtc.ChildLifetimeScopeBeginning += e,
+            e => mtc.ChildLifetimeScopeBeginning -= e,
+            () => mtc.GetTenantScope("tenant1").BeginLifetimeScope());
+    }
+
+    [Fact]
+    public void CurrentScopeEnding_FiresWhenScopeDisposed()
+    {
+        var strategy = new StubTenantIdentificationStrategy()
+        {
+            TenantId = "tenant1",
+        };
+        using var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+        mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl1>().As<IStubDependency1>());
+
+        Assert.Raises<LifetimeScopeEndingEventArgs>(
+            e => mtc.CurrentScopeEnding += e,
+            e => mtc.CurrentScopeEnding -= e,
+            () => mtc.RemoveTenant("tenant1"));
     }
 }

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -519,6 +519,21 @@ public class MultitenantContainerFixture
     }
 
     [Fact]
+    public void RemoveTenant_ReturnsFalseWhenNotPresent()
+    {
+        var strategy = new StubTenantIdentificationStrategy()
+        {
+            TenantId = "tenant1",
+        };
+        using var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
+        mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDisposableDependency>().SingleInstance());
+
+        var removed = mtc.RemoveTenant("tenant2");
+
+        Assert.False(removed);
+    }
+
+    [Fact]
     public void ReconfigureTenant_Reconfigure()
     {
         var strategy = new StubTenantIdentificationStrategy()

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -125,6 +125,19 @@ public class MultitenantContainerFixture
     }
 
     [Fact]
+    public void ConfigureTenant_ThrowsAfterDisposal()
+    {
+        var builder = new ContainerBuilder();
+        var strategy = new StubTenantIdentificationStrategy()
+        {
+            TenantId = "tenant1",
+        };
+        using var mtc = new MultitenantContainer(strategy, builder.Build());
+        mtc.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => mtc.ConfigureTenant("tenant1", _ => { }));
+    }
+
+    [Fact]
     public void Ctor_NullApplicationContainer()
     {
         Assert.Throws<ArgumentNullException>(() => new MultitenantContainer(new StubTenantIdentificationStrategy(), null));


### PR DESCRIPTION
Hello,

we encountered a bug when using IAsyncDisposable. It seems that MultitenantContainer's DisposeAsync wrongly uses ReaderWriterLockSlim in async context, because it internally compares locking and releasing thread ID. More here: https://stackoverflow.com/questions/19659387/readerwriterlockslim-and-async-await

According to aforementioned issue it seems to be the best option to use SemaphoreSlim instead of relying on custom or 3rd party implementation of AsyncReaderWriterLock.

Thank you in advance for merging.
N.