### PR TITLE
Update for .NET 8, Autofac 8.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: '7.0.1.{build}'
+version: '8.0.0.{build}'
 
 dotnet_csproj:
-  version_prefix: '7.0.1'
+  version_prefix: '8.0.0'
   patch: true
   file: 'src\**\*.csproj'
 

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -8,6 +8,8 @@
     <Rule Id="CA1510" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Cache a 'CompositeFormat' for repeated use in formatting - we only format exception messages and this isn't supported in other .NET targets, so it's not interesting to optimize. -->
+    <Rule Id="CA1863" Action="None" />
     <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -14,6 +14,8 @@
     <Rule Id="CA1822" Action="None" />
     <!-- Seal internal types - tests use internal types for stubs and performance isn't a problem; this causes unnecessary ceremony. -->
     <Rule Id="CA1852" Action="None" />
+    <!-- Call ConfigureAwait - conflicts with xUnit1030 and may cause test parallelization limits to be bypassed. -->
+    <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,10 @@
 {
   "sdk": {
-    "version": "7.0.306",
+    "version": "8.0.101",
     "rollForward": "latestFeature"
-  }
+  },
+  "additionalSdks": [
+    "6.0.418",
+    "7.0.405"
+  ]
 }

--- a/src/Autofac.Multitenant/Autofac.Multitenant.csproj
+++ b/src/Autofac.Multitenant/Autofac.Multitenant.csproj
@@ -61,15 +61,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Autofac.Multitenant/Autofac.Multitenant.csproj
+++ b/src/Autofac.Multitenant/Autofac.Multitenant.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="7.1.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -341,6 +341,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// Creates new tenant scope without any locking. Uses optimistic approach - creates the scope and in case it fails to insert to the dictionary it's immediately disposed.
     /// This should happen very rarely, hopefully never.
     /// </summary>
+    [SuppressMessage("CA1513", "CA1513", Justification = "ObjectDisposedException.ThrowIf is not available in all target frameworks.")]
     private ILifetimeScope CreateTenantScope(object tenantId, Action<ContainerBuilder>? configuration = null)
     {
         if (_isDisposed == 1)
@@ -458,12 +459,11 @@ public class MultitenantContainer : Disposable, IContainer
     /// <summary>
     /// Returns collection of all registered tenants IDs.
     /// </summary>
-#pragma warning disable CA1024
+    [SuppressMessage("CA1024", "CA1024", Justification = "Iterating the tenants allocates memory and locks the keys, so a method is appropriate to signify it's more than a fixed set of things.")]
     public IEnumerable<object> GetTenants()
     {
         return new List<object>(_tenantLifetimeScopes.Keys);
     }
-#pragma warning restore CA1024
 
     /// <summary>
     /// Returns whether the given tenant ID has been configured.
@@ -524,7 +524,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// if the component registered requires another component be available
     /// but that required component is not available, this exception will be thrown.
     /// </exception>
-    public object ResolveComponent(ResolveRequest request)
+    public object ResolveComponent(in ResolveRequest request)
     {
         return GetCurrentTenantScope().ResolveComponent(request);
     }

--- a/test/Autofac.Multitenant.AspNetCore.Test/Autofac.Multitenant.AspNetCore.Test.csproj
+++ b/test/Autofac.Multitenant.AspNetCore.Test/Autofac.Multitenant.AspNetCore.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -37,14 +37,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.AspNetCore.Test/Autofac.Multitenant.AspNetCore.Test.csproj
+++ b/test/Autofac.Multitenant.AspNetCore.Test/Autofac.Multitenant.AspNetCore.Test.csproj
@@ -38,13 +38,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.Test/Autofac.Multitenant.Test.csproj
+++ b/test/Autofac.Multitenant.Test/Autofac.Multitenant.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -36,13 +36,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.Test/Autofac.Multitenant.Test.csproj
+++ b/test/Autofac.Multitenant.Test/Autofac.Multitenant.Test.csproj
@@ -36,13 +36,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -755,7 +755,7 @@ public class MultitenantContainerFixture
         var mtc = new MultitenantContainer(strategy, new ContainerBuilder().Build());
         mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl1>().As<IStubDependency1>());
 
-        await mtc.DisposeAsync().ConfigureAwait(false);
+        await mtc.DisposeAsync();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #36 

- **BREAKING**: Update core Autofac to 8.0.0 and fix `MultitenantContainer.ResolveComponent` to account for `ResolveRequest` now being a `readonly struct`.
- Add support for .NET 8.
- Update test/analyzer dependencies.
- Semver updated to 8.0.0 for the core Autofac update that includes a breaking change.