### PR TITLE
Fix a race condition in ReconfigureTenant

### DIFF
--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -342,7 +342,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// This should happen very rarely, hopefully never.
     /// </summary>
     [SuppressMessage("CA1513", "CA1513", Justification = "ObjectDisposedException.ThrowIf is not available in all target frameworks.")]
-    private ILifetimeScope CreateTenantScope(object tenantId, Action<ContainerBuilder>? configuration = null)
+    private ILifetimeScope CreateTenantScope(object tenantId, Action<ContainerBuilder>? configuration = null, bool forced = false)
     {
         if (_isDisposed == 1)
         {
@@ -353,7 +353,17 @@ public class MultitenantContainer : Disposable, IContainer
             ? ApplicationContainer.BeginLifetimeScope(TenantLifetimeScopeTag, configuration)
             : ApplicationContainer.BeginLifetimeScope(TenantLifetimeScopeTag);
 
-        var setLifetimeScope = _tenantLifetimeScopes.GetOrAdd(tenantId, lifetimeScope);
+        var setLifetimeScope = lifetimeScope;
+        if (forced)
+        {
+            // When reconfiguring the tenant, we make sure another thread is not
+            // getting/creating the scope at the same time.
+            _tenantLifetimeScopes[tenantId] = lifetimeScope;
+        }
+        else
+        {
+            setLifetimeScope = _tenantLifetimeScopes.GetOrAdd(tenantId, lifetimeScope);
+        }
 
         if (setLifetimeScope != lifetimeScope)
         {
@@ -410,7 +420,7 @@ public class MultitenantContainer : Disposable, IContainer
             removed = true;
         }
 
-        CreateTenantScope(tenantId, configuration);
+        CreateTenantScope(tenantId, configuration, true);
 
         return removed;
     }

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -404,6 +404,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// <returns><c>true</c> if an existing configuration was removed; otherwise, <c>false</c>.</returns>
     /// <seealso cref="ConfigurationActionBuilder"/>
     /// <seealso cref="ConfigureTenant(object, Action{ContainerBuilder})"/>
+    [SuppressMessage("CA1513", "CA1513", Justification = "ObjectDisposedException.ThrowIf is not available in all target frameworks.")]
     public bool ReconfigureTenant(object tenantId, Action<ContainerBuilder> configuration)
     {
         if (configuration == null)
@@ -411,18 +412,35 @@ public class MultitenantContainer : Disposable, IContainer
             throw new ArgumentNullException(nameof(configuration));
         }
 
-        tenantId ??= _defaultTenantId;
-
-        var removed = false;
-        if (_tenantLifetimeScopes.TryRemove(tenantId, out var tenantScope))
+        if (_isDisposed == 1)
         {
-            tenantScope.Dispose();
-            removed = true;
+            throw new ObjectDisposedException(nameof(ApplicationContainer));
         }
 
-        CreateTenantScope(tenantId, configuration, true);
+        tenantId ??= _defaultTenantId;
 
-        return removed;
+        var lifetimeScope = ApplicationContainer.BeginLifetimeScope(TenantLifetimeScopeTag, configuration);
+
+        ILifetimeScope? disposedLifetimeScope = null;
+        _tenantLifetimeScopes.AddOrUpdate(
+            tenantId,
+            _ => lifetimeScope,
+            (_, updatedLifetimeScope) =>
+            {
+                // We defer the existing scope Dispose()
+                // as we prefer enabling the new scope as quickly
+                // as possible.
+                disposedLifetimeScope = updatedLifetimeScope;
+                return lifetimeScope;
+            });
+
+        if (disposedLifetimeScope == null)
+        {
+            return false;
+        }
+
+        disposedLifetimeScope.Dispose();
+        return true;
     }
 
     /// <summary>

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -342,7 +342,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// This should happen very rarely, hopefully never.
     /// </summary>
     [SuppressMessage("CA1513", "CA1513", Justification = "ObjectDisposedException.ThrowIf is not available in all target frameworks.")]
-    private ILifetimeScope CreateTenantScope(object tenantId, Action<ContainerBuilder>? configuration = null, bool forced = false)
+    private ILifetimeScope CreateTenantScope(object tenantId, Action<ContainerBuilder>? configuration = null)
     {
         if (_isDisposed == 1)
         {
@@ -353,17 +353,7 @@ public class MultitenantContainer : Disposable, IContainer
             ? ApplicationContainer.BeginLifetimeScope(TenantLifetimeScopeTag, configuration)
             : ApplicationContainer.BeginLifetimeScope(TenantLifetimeScopeTag);
 
-        var setLifetimeScope = lifetimeScope;
-        if (forced)
-        {
-            // When reconfiguring the tenant, we make sure another thread is not
-            // getting/creating the scope at the same time.
-            _tenantLifetimeScopes[tenantId] = lifetimeScope;
-        }
-        else
-        {
-            setLifetimeScope = _tenantLifetimeScopes.GetOrAdd(tenantId, lifetimeScope);
-        }
+        var setLifetimeScope = _tenantLifetimeScopes.GetOrAdd(tenantId, lifetimeScope);
 
         if (setLifetimeScope != lifetimeScope)
         {


### PR DESCRIPTION
ReconfigureTenant  removes the tenant scope before adding the reconfigured one. If another thread calls GetTenantScope between the remove and the add, an empty scope is kept in the _tenantLifetimeScopes dictionary.