### PR TITLE
Update nullable annotations to correct handling of tenant ID

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,9 +3,8 @@
     "bierner.markdown-emoji",
     "davidanson.vscode-markdownlint",
     "editorconfig.editorconfig",
-    "formulahendry.dotnet-test-explorer",
     "gruntfuggly.todo-tree",
-    "ms-dotnettools.csharp",
+    "ms-dotnettools.csdevkit",
     "ryanluker.vscode-coverage-gutters",
     "stkb.rewrap",
     "travisillig.vscode-json-stable-stringify"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: '8.0.1.{build}'
+version: '8.0.2.{build}'
 
 dotnet_csproj:
-  version_prefix: '8.0.1'
+  version_prefix: '8.0.2'
   patch: true
   file: 'src\**\*.csproj'
 

--- a/src/Autofac.Multitenant/ITenantIdentificationStrategy.cs
+++ b/src/Autofac.Multitenant/ITenantIdentificationStrategy.cs
@@ -20,5 +20,5 @@ public interface ITenantIdentificationStrategy
     /// if not.
     /// </returns>
     [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "Tenant identifiers are objects.")]
-    bool TryIdentifyTenant(out object tenantId);
+    bool TryIdentifyTenant(out object? tenantId);
 }

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -320,7 +320,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// </exception>
     /// <seealso cref="ConfigurationActionBuilder"/>
     /// <seealso cref="ReconfigureTenant(object, Action{ContainerBuilder})"/>
-    public void ConfigureTenant(object tenantId, Action<ContainerBuilder> configuration)
+    public void ConfigureTenant(object? tenantId, Action<ContainerBuilder> configuration)
     {
         if (configuration == null)
         {

--- a/src/Autofac.Multitenant/TenantIdentificationStrategyExtensions.cs
+++ b/src/Autofac.Multitenant/TenantIdentificationStrategyExtensions.cs
@@ -31,9 +31,9 @@ public static class TenantIdentificationStrategyExtensions
             throw new ArgumentNullException(nameof(strategy));
         }
 
-        if (strategy.TryIdentifyTenant(out object id))
+        if (strategy.TryIdentifyTenant(out var id))
         {
-            return (T)id;
+            return (T?)id;
         }
 
         return default;

--- a/test/Autofac.Multitenant.AspNetCore.Test/Autofac.Multitenant.AspNetCore.Test.csproj
+++ b/test/Autofac.Multitenant.AspNetCore.Test/Autofac.Multitenant.AspNetCore.Test.csproj
@@ -12,6 +12,7 @@
     <LangVersion>latest</LangVersion>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,22 +30,22 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.AspNetCore.Test/Stubs/StubTenantIdentificationStrategy.cs
+++ b/test/Autofac.Multitenant.AspNetCore.Test/Stubs/StubTenantIdentificationStrategy.cs
@@ -12,9 +12,9 @@ public class StubTenantIdentificationStrategy : ITenantIdentificationStrategy
 
     public bool IdentificationSuccess { get; set; }
 
-    public object TenantId { get; set; }
+    public object? TenantId { get; set; }
 
-    public bool TryIdentifyTenant(out object tenantId)
+    public bool TryIdentifyTenant(out object? tenantId)
     {
         tenantId = TenantId;
         return IdentificationSuccess;

--- a/test/Autofac.Multitenant.Test/Autofac.Multitenant.Test.csproj
+++ b/test/Autofac.Multitenant.Test/Autofac.Multitenant.Test.csproj
@@ -12,6 +12,7 @@
     <LangVersion>latest</LangVersion>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,21 +29,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
+++ b/test/Autofac.Multitenant.Test/MultitenantContainerFixture.cs
@@ -123,7 +123,7 @@ public class MultitenantContainerFixture
             TenantId = "tenant1",
         };
         using var mtc = new MultitenantContainer(strategy, builder.Build());
-        Assert.Throws<ArgumentNullException>(() => mtc.ConfigureTenant("tenant1", null));
+        Assert.Throws<ArgumentNullException>(() => mtc.ConfigureTenant("tenant1", null!));
     }
 
     [Fact]
@@ -142,13 +142,13 @@ public class MultitenantContainerFixture
     [Fact]
     public void Ctor_NullApplicationContainer()
     {
-        Assert.Throws<ArgumentNullException>(() => new MultitenantContainer(new StubTenantIdentificationStrategy(), null));
+        Assert.Throws<ArgumentNullException>(() => new MultitenantContainer(new StubTenantIdentificationStrategy(), null!));
     }
 
     [Fact]
     public void Ctor_NullTenantIdentificationStrategy()
     {
-        Assert.Throws<ArgumentNullException>(() => new MultitenantContainer(null, new ContainerBuilder().Build()));
+        Assert.Throws<ArgumentNullException>(() => new MultitenantContainer(null!, new ContainerBuilder().Build()));
     }
 
     [Fact]
@@ -578,7 +578,7 @@ public class MultitenantContainerFixture
         using var mtc = new MultitenantContainer(strategy, builder.Build());
         mtc.ConfigureTenant("tenant1", b => b.RegisterType<StubDependency1Impl2>().AsImplementedInterfaces().SingleInstance());
 
-        Assert.Throws<ArgumentNullException>(() => mtc.ReconfigureTenant("tenant1", null));
+        Assert.Throws<ArgumentNullException>(() => mtc.ReconfigureTenant("tenant1", null!));
     }
 
     [Fact]

--- a/test/Autofac.Multitenant.Test/RegistrationExtensionsFixture.cs
+++ b/test/Autofac.Multitenant.Test/RegistrationExtensionsFixture.cs
@@ -11,7 +11,7 @@ public class RegistrationExtensionsFixture
     [Fact]
     public void InstancePerTenant_NullRegistration()
     {
-        IRegistrationBuilder<StubDependency1Impl1, ConcreteReflectionActivatorData, SingleRegistrationStyle> registration = null;
+        IRegistrationBuilder<StubDependency1Impl1, ConcreteReflectionActivatorData, SingleRegistrationStyle> registration = null!;
         Assert.Throws<ArgumentNullException>(() => registration.InstancePerTenant());
     }
 

--- a/test/Autofac.Multitenant.Test/Stubs/StubTenantIdentificationStrategy.cs
+++ b/test/Autofac.Multitenant.Test/Stubs/StubTenantIdentificationStrategy.cs
@@ -12,9 +12,9 @@ public class StubTenantIdentificationStrategy : ITenantIdentificationStrategy
 
     public bool IdentificationSuccess { get; set; }
 
-    public object TenantId { get; set; }
+    public object? TenantId { get; set; }
 
-    public bool TryIdentifyTenant(out object tenantId)
+    public bool TryIdentifyTenant(out object? tenantId)
     {
         tenantId = TenantId;
         return IdentificationSuccess;

--- a/test/Autofac.Multitenant.Test/TenantIdentificationStrategyExtensionsFixture.cs
+++ b/test/Autofac.Multitenant.Test/TenantIdentificationStrategyExtensionsFixture.cs
@@ -30,7 +30,7 @@ public class TenantIdentificationStrategyExtensionsFixture
     [Fact]
     public void IdentifyTenant_NullStrategy()
     {
-        ITenantIdentificationStrategy strategy = null;
+        ITenantIdentificationStrategy strategy = null!;
         Assert.Throws<ArgumentNullException>(() => strategy.IdentifyTenant<Guid>());
     }
 


### PR DESCRIPTION
Two scenarios had incorrect nullable annotations:

1. When identifying a tenant (`TryIdentifyTenant`), if the tenant was _not_ successfully identified, the output tenant ID should be allowed to be null.
2. When configuring a tenant lifetime scope, `ConfigureTenant` should allow a `null` tenant ID to indicate the "default tenant."

As part of this I enabled nullable annotations on the unit test projects to ensure things were lining up and allow us to see the nullable warnings when violations in test fixtures occur.

Includes a semver update from 8.0.1 => 8.0.2 for this fix. (My commit message has a typo. 😦 )