### PR TITLE
Nullable annotation fixes for consistency

### DIFF
--- a/src/Autofac.Multitenant/ITenantIdentificationStrategy.cs
+++ b/src/Autofac.Multitenant/ITenantIdentificationStrategy.cs
@@ -19,6 +19,15 @@ public interface ITenantIdentificationStrategy
     /// <see langword="true" /> if the tenant could be identified; <see langword="false" />
     /// if not.
     /// </returns>
+    /// <remarks>
+    /// <para>
+    /// It is technically possible to allow the tenant to be identified but
+    /// still have the tenant ID come out as <see langword="null"/>. If this
+    /// happens, it indicates the strategy has intentionally chosen the "default
+    /// tenant" as the active tenant rather than requiring fallback logic to
+    /// occur.
+    /// </para>
+    /// </remarks>
     [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "Tenant identifiers are objects.")]
     bool TryIdentifyTenant(out object? tenantId);
 }

--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -395,7 +395,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// <seealso cref="ConfigurationActionBuilder"/>
     /// <seealso cref="ConfigureTenant(object, Action{ContainerBuilder})"/>
     [SuppressMessage("CA1513", "CA1513", Justification = "ObjectDisposedException.ThrowIf is not available in all target frameworks.")]
-    public bool ReconfigureTenant(object tenantId, Action<ContainerBuilder> configuration)
+    public bool ReconfigureTenant(object? tenantId, Action<ContainerBuilder> configuration)
     {
         if (configuration == null)
         {
@@ -488,7 +488,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// </summary>
     /// <param name="tenantId">The tenant ID to test.</param>
     /// <returns>If configured, <c>true</c>; otherwise <c>false</c>.</returns>
-    public bool TenantIsConfigured(object tenantId)
+    public bool TenantIsConfigured(object? tenantId)
     {
         tenantId ??= _defaultTenantId;
 
@@ -500,7 +500,7 @@ public class MultitenantContainer : Disposable, IContainer
     /// </summary>
     /// <param name="tenantId">The ID of the tenant to dispose.</param>
     /// <returns><c>true</c> if the tenant-collection was modified; otherwise, <c>false</c>.</returns>
-    public bool RemoveTenant(object tenantId)
+    public bool RemoveTenant(object? tenantId)
     {
         tenantId ??= _defaultTenantId;
 


### PR DESCRIPTION
Fixes #40.

Issue #40 indicated that the `ITenantIdentificationStrategy.TryIdentifyTenant` was allowing for a null return value if the method returned `true`.

While I think this is a super edge case, technically speaking we _do_ have the concept of a "default tenant" in the system that is indicated by a `null` tenant ID. Thus, it _is technically possible_ someone may want to say, "I looked, and I intentionally have determined that we should use the default tenant ID, thus I am intentionally setting the return value to `null`."

I found that we weren't correctly handling all nullable annotations in `MultitenantContainer`, so that has been updated. I've also added some documentation to explain the potential intentional `null`; and some unit tests to illustrate more of the notion of intentional identification-as-null.

The other option here would be to make a change to the `TryIdentifyTenant` method definition such that it's _not_ allowed to return `null` if the tenant is identified. I think it's possible this is a breaking change given that sort of behavior is currently allowed and we've definitely seen people doing every possible edge case out there, even if it's not the 80% case. If we did that, it may be that we need to have a public/singleton for the default tenant ID such that an intentional identification as the default tenant will result in a non-null tenant ID. Not a huge lift, but not just a nullable annotation change, either.