### PR TITLE
Async versions of ReconfigureTenant, ClearTenants and RemoveTenant

### DIFF
--- a/src/Autofac.Multitenant/MultitenantContainer.cs
+++ b/src/Autofac.Multitenant/MultitenantContainer.cs
@@ -435,8 +435,7 @@ public class MultitenantContainer : Disposable, IContainer
 
     /// <summary>
     /// Allows re-configuration of tenant-specific components by closing and rebuilding
-    /// the tenant scope.
-    /// The closed scope is disposed asynchronously.
+    /// the tenant scope. The closed scope is disposed asynchronously.
     /// </summary>
     /// <param name="tenantId">
     /// The ID of the tenant for which configuration is occurring. If this


### PR DESCRIPTION
Since we may have reasons to use DisposeAsync, we should have async versions of these methods as well.

I'll gladly add tests, but wonder what style you prefer if there are sync/async versions. Clone the test? Parametrize?