### PR TITLE
Update dependencies (Autofac 9.3.1)

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <SolutionName>Autofac.Multitenant</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Multitenant/Autofac.Multitenant.csproj
+++ b/src/Autofac.Multitenant/Autofac.Multitenant.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Updated `Autofac` package reference from 9.3.0 to 9.3.1 (patch update, backwards-compatible bug fixes)
- Bumped package version from 9.0.0 to 9.0.1

## Dependency Changes

| Package | Old | New | Category |
|---------|-----|-----|----------|
| Autofac | 9.3.0 | 9.3.1 | Shipping/src dependency |

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] No breaking API changes (patch update to Autofac)